### PR TITLE
Fix JSON property name for user images (60x60 not 60x)

### DIFF
--- a/PinSharp/Models/Images/UserImages.cs
+++ b/PinSharp/Models/Images/UserImages.cs
@@ -4,16 +4,16 @@ namespace PinSharp.Models.Images
 {
     public class UserImages
     {
-        [JsonProperty("60x")]
+        [JsonProperty("60x60")]
         public ImageInfo W60 { get; set; }
 
-        [JsonProperty("110x")]
+        [JsonProperty("110x110")]
         public ImageInfo W110 { get; set; }
 
-        [JsonProperty("165x")]
+        [JsonProperty("165x165")]
         public ImageInfo W165 { get; set; }
 
-        [JsonProperty("280x")]
+        [JsonProperty("280x280")]
         public ImageInfo W280 { get; set; }
     }
 }


### PR DESCRIPTION
UserImages wasn't working, at least off of GetPins. I.e. myPin.Creator.Images.W60 was null. Checking the response from Pinterest, it seems the name is "60x60", not "60x". I was unable to get higher res images than 60px. Not sure if this is a limitation in their API, or all the ones I tried just had low res.